### PR TITLE
Fix logger trait returning type

### DIFF
--- a/src/Spryker/Shared/Log/LoggerConfig/LoggerConfigLoader.php
+++ b/src/Spryker/Shared/Log/LoggerConfig/LoggerConfigLoader.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Shared\Log\LoggerConfig;
 
+use Spryker\Shared\Log\Config\LoggerConfigInterface;
 use Spryker\Shared\Log\Exception\LoggerLoaderException;
 
 class LoggerConfigLoader
@@ -29,7 +30,7 @@ class LoggerConfigLoader
      *
      * @return \Spryker\Shared\Log\Config\LoggerConfigInterface
      */
-    public function getLoggerConfig()
+    public function getLoggerConfig(): LoggerConfigInterface
     {
         foreach ($this->loggerLoader as $loggerLoader) {
             if ($loggerLoader->accept()) {

--- a/src/Spryker/Shared/Log/LoggerFactory.php
+++ b/src/Spryker/Shared/Log/LoggerFactory.php
@@ -8,6 +8,7 @@
 namespace Spryker\Shared\Log;
 
 use Monolog\Logger as MonologLogger;
+use Psr\Log\LoggerInterface;
 use Spryker\Shared\Log\Config\LoggerConfigInterface;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoader;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderDefault;
@@ -30,9 +31,9 @@ class LoggerFactory
     /**
      * @param \Spryker\Shared\Log\Config\LoggerConfigInterface|null $loggerConfig
      *
-     * @return \Psr\Log\LoggerInterface|null
+     * @return \Psr\Log\LoggerInterface
      */
-    public static function getInstance(?LoggerConfigInterface $loggerConfig = null)
+    public static function getInstance(?LoggerConfigInterface $loggerConfig = null): LoggerInterface
     {
         if ($loggerConfig === null) {
             if (!static::$loggerConfig) {
@@ -50,7 +51,7 @@ class LoggerFactory
      *
      * @return \Psr\Log\LoggerInterface
      */
-    protected static function createInstanceIfNotExists(LoggerConfigInterface $loggerConfig)
+    protected static function createInstanceIfNotExists(LoggerConfigInterface $loggerConfig): LoggerInterface
     {
         $channelName = $loggerConfig->getChannelName();
 

--- a/src/Spryker/Shared/Log/LoggerFactory.php
+++ b/src/Spryker/Shared/Log/LoggerFactory.php
@@ -13,6 +13,7 @@ use Spryker\Shared\Log\Config\LoggerConfigInterface;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoader;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderDefault;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderGlue;
+use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderInterface;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderYves;
 use Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderZed;
 
@@ -67,7 +68,7 @@ class LoggerFactory
     /**
      * @return \Spryker\Shared\Log\Config\LoggerConfigInterface
      */
-    protected static function createLoggerConfig()
+    protected static function createLoggerConfig(): LoggerConfigInterface
     {
         $loggerConfigLoader = new LoggerConfigLoader([
             static::createLoggerConfigLoaderYves(),
@@ -82,7 +83,7 @@ class LoggerFactory
     /**
      * @return \Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderInterface|\Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderYves
      */
-    protected static function createLoggerConfigLoaderYves()
+    protected static function createLoggerConfigLoaderYves(): LoggerConfigLoaderInterface
     {
         return new LoggerConfigLoaderYves();
     }
@@ -90,7 +91,7 @@ class LoggerFactory
     /**
      * @return \Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderInterface|\Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderZed
      */
-    protected static function createLoggerConfigLoaderZed()
+    protected static function createLoggerConfigLoaderZed(): LoggerConfigLoaderInterface
     {
         return new LoggerConfigLoaderZed();
     }
@@ -98,7 +99,7 @@ class LoggerFactory
     /**
      * @return \Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderInterface|\Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderGlue
      */
-    protected static function createLoggerConfigLoaderGlue()
+    protected static function createLoggerConfigLoaderGlue(): LoggerConfigLoaderInterface
     {
         return new LoggerConfigLoaderGlue();
     }
@@ -106,7 +107,7 @@ class LoggerFactory
     /**
      * @return \Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderInterface|\Spryker\Shared\Log\LoggerConfig\LoggerConfigLoaderDefault
      */
-    protected static function createLoggerConfigLoaderDefault()
+    protected static function createLoggerConfigLoaderDefault(): LoggerConfigLoaderInterface
     {
         return new LoggerConfigLoaderDefault();
     }

--- a/src/Spryker/Shared/Log/LoggerTrait.php
+++ b/src/Spryker/Shared/Log/LoggerTrait.php
@@ -7,6 +7,7 @@
 
 namespace Spryker\Shared\Log;
 
+use Psr\Log\LoggerInterface;
 use Spryker\Shared\Log\Config\LoggerConfigInterface;
 
 trait LoggerTrait
@@ -14,9 +15,9 @@ trait LoggerTrait
     /**
      * @param \Spryker\Shared\Log\Config\LoggerConfigInterface|null $loggerConfig
      *
-     * @return \Psr\Log\LoggerInterface|null
+     * @return \Psr\Log\LoggerInterface
      */
-    protected function getLogger(?LoggerConfigInterface $loggerConfig = null)
+    protected function getLogger(?LoggerConfigInterface $loggerConfig = null): LoggerInterface
     {
         return LoggerFactory::getInstance($loggerConfig);
     }


### PR DESCRIPTION
## PR Description

As I already wrote in the [Spryker Community Slack Channel](https://sprykercommunity.slack.com/archives/CH2HA71C5/p1619432281105600), the `LoggerTrait::getLogguer()` return type is not right, it cannot return a null, therefore saying that it's allowing to return a null can adding some extra complexity (unnecesray null checks?!) when aiming for a PHPStan max(8) level, for example. 

But the most important thing is that the API is simply not updated.

Here I updated the returning type from the Shared `LoggerTrait::getLogguer()` + I added some returning types that were missing in this context.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
